### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cd real-world-ruby-apps/
 
 # The apps are linked to as git submodules.
 # This will take some time...
-git submodule update --init
+git submodule update --init --remote --merge
 ```
 
 ## Other Real World codebase collections


### PR DESCRIPTION
Without `--remote --merge` `git submodule --init` ends up with:

    Submodule path 'apps/procodile': checked out '747ae0ffac332b01ee27aa1a2c6d3d8492b4d62a'
    Submodule path 'apps/pru': checked out 'bac7fe4aa31823bd927d3dc21cbe997c2de58512'
    error: Server does not allow request for unadvertised object f177c95b13c4d702c145885d8fe611abbe603d6b
    Fetched in submodule path 'apps/pry', but it did not contain f177c95b13c4d702c145885d8fe611abbe603d6b. Direct fetching of that commit failed.

Not sure what was the reason, probably a rebase in `master` of `pry`, and the commit the submodule was pointing is not in the history anymore.

Those options appeared in git 1.8.2.

From `man git-submodule`:

> --remote This option is only valid for the update command. Instead of using the superproject's recorded SHA-1 to update the submodule, use the status of the submodule's remote-tracking branch.

> --merge the commit recorded in the superproject will be merged into the current branch in the submodule.

It was still possible to fetch `pry` by issuing:

    git submodule foreach git checkout master

However, it was frustrating and not obvious.